### PR TITLE
Add ability to switch off git-flow mode, Slack channel override

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ merged-prs is a go tool to assit in determining differences between git hashes b
 
 ## Requirements
 
-- Go 1.5
+- Go 1.6
 - GPM
 - Git
 - GitHub
@@ -14,8 +14,8 @@ merged-prs is a go tool to assit in determining differences between git hashes b
 
 - Built in Go
 - Given a set of git hashes, a list of merged GitHub Pull Requests will be retrieved and parsed.
-- List will be output to console contining the PR #, Author, Summary, and a link to the PR
-- If Slack credentials are configured, a notification will be sent to the channel of your choosing
+- List will be output to console containing the PR #, Author, Summary, and a link to the PR
+- If Slack credentials are configured, a notification will be sent to the channel of your choosing (from config, or override)
 
 ## Configuration
 
@@ -59,15 +59,16 @@ Calling the `merged-prs` tool will act in the current directory's context.
 
 ```
 # Runtime Flags
-  -test <do not notify Slack, only output to console>
-  -path <Specify path to repo in order to use outside the context of a repo>
-
+  -path       <Specify path to repo in order to use outside the context of a repo>
+  -dev=false  <Ignore the git-flow dev branch paradigm (loose comparison "...")>
+  -test       <Do not notify Slack, only output to console>
+  -c          <Override default slack notification channel>
 ```
 
 ### Example
 
 ```
-# merged-prs [-test] [-path /path/to/repo] [Previous Git Hash] [Current Git Hash]
+# merged-prs [-test] [-c @lucas] [-dev=false] [-path /path/to/repo] [Previous Git Hash] [Current Git Hash]
 # User should specify the older revision first ie. merging `dev` into `master` would necessitate that `master` is the older commit, and `dev` is the newer
 
 $ merged-prs master dev

--- a/utils.go
+++ b/utils.go
@@ -17,17 +17,25 @@ func parseArgs() (string, string) {
 	return a[0], a[1]
 }
 
-func parseFlags() (string, bool) {
-	var path string
-	var test bool
+type Flags struct {
+	Path         *string
+	Test         *bool
+	Dev          *bool
+	SlackChannel *string
+}
 
+func parseFlags() *Flags {
+
+	flags := &Flags{}
 	wd, _ := os.Getwd()
 
-	flag.StringVar(&path, "path", wd, "Path to git repo, defaults to working directory.")
-	flag.BoolVar(&test, "test", false, "Run command in test mode (do not notify Slack)")
+	flags.Path = flag.String("path", wd, "Path to git repo, defaults to working directory.")
+	flags.Test = flag.Bool("test", false, "Run command in test mode (do not notify Slack)")
+	flags.Dev = flag.Bool("dev", true, "Run merge comparison with strict checking (..) versus (...), necessary for the `dev` branch paradigm")
+	flags.SlackChannel = flag.String("c", "", "Override default Slack channel as defined in config")
 	flag.Parse()
 
-	return path, test
+	return flags
 }
 
 func checkForGit() {


### PR DESCRIPTION
Small updates prior to rewrite release
- Adding in ability to disable the `git-flow` model paradigm, (feature > dev > master). `-dev=false`
- Added ability to override default Slack channel `-c`

When projects do not use a dev > master branching paradigm within GitHub it is necessary to use the loose merge comparison `...` to grab all the commits. When using the loose matching `...` in a git-flow paradigm, any hotfixes against `master` will always appear in the change log.

Also added the ability to override the default Slack channel with the `-c @lucas` flag.

@bshackelford
