### PR TITLE
Update to use Glide

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 merged-prs
+vendor/

--- a/Godeps
+++ b/Godeps
@@ -1,5 +1,0 @@
-github.com/fatih/color
-github.com/google/go-github/github
-github.com/rodaine/table
-golang.org/x/oauth2
-github.com/hashicorp/hcl

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ merged-prs is a go tool to assit in determining differences between git hashes b
 ## Requirements
 
 - Go 1.6
-- GPM
+- Glide
 - Git
 - GitHub
 - Slack (optional)
@@ -47,7 +47,7 @@ In order to use the `merged-prs` tool one should use `go get`
 ```
 go get github.com/promiseofcake/merged-prs
 cd $GOPATH/src/github.com/promiseofcake/merged-prs
-gpm install
+glide install
 go install
 ```
 

--- a/glide.lock
+++ b/glide.lock
@@ -1,0 +1,51 @@
+hash: 8ca23f808d097ff7f16a14cd1f5315ef807441900daa378db44daba67a298937
+updated: 2017-01-23T18:05:49.865501255-05:00
+imports:
+- name: github.com/fatih/color
+  version: 34e4ee095d12986a2cef5ddb9aeb3b8cfcfea17c
+- name: github.com/golang/protobuf
+  version: 0c1f6d65b5a189c2250d10e71a5506f06f9fa0a0
+  subpackages:
+  - proto
+- name: github.com/google/go-github
+  version: a59a35745f99ad92d70d69a9f180767063aa4bf3
+  subpackages:
+  - github
+- name: github.com/google/go-querystring
+  version: 9235644dd9e52eeae6fa48efd539fdc351a0af53
+  subpackages:
+  - query
+- name: github.com/hashicorp/hcl
+  version: 578dd9746824a54637686b51a41bad457a56bcef
+  subpackages:
+  - hcl/ast
+  - hcl/parser
+  - hcl/scanner
+  - hcl/strconv
+  - hcl/token
+  - json/parser
+  - json/scanner
+  - json/token
+- name: github.com/lytics/slackhook
+  version: a52fd449b27dcdd75cf069c5d6ac5749653d801a
+- name: github.com/rodaine/table
+  version: c35ded4ccfec23e952469a4de8edc168e61c8d58
+- name: golang.org/x/net
+  version: 6050c111928ef9186beb82e4395437607bb24bdb
+  subpackages:
+  - context
+- name: golang.org/x/oauth2
+  version: 314dd2c0bf3ebd592ec0d20847d27e79d0dbe8dd
+  subpackages:
+  - internal
+- name: google.golang.org/appengine
+  version: a2c54d2174c17540446e0ced57d9d459af61bc1c
+  subpackages:
+  - internal
+  - internal/base
+  - internal/datastore
+  - internal/log
+  - internal/remote_api
+  - internal/urlfetch
+  - urlfetch
+testImports: []

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,0 +1,11 @@
+package: github.com/promiseofcake/merged-prs
+import:
+- package: github.com/fatih/color
+  version: ^1.2.0
+- package: github.com/google/go-github
+  subpackages:
+  - github
+- package: github.com/rodaine/table
+- package: golang.org/x/oauth2
+- package: github.com/hashicorp/hcl
+- package: github.com/lytics/slackhook


### PR DESCRIPTION
* Switch to glide -- $GOPATH isn't suitable anymore
* Changing documentation for how to install

Users were having problems installing so switching to a vendor-based install. 